### PR TITLE
fix: pagination throws error on panel change

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,6 @@
 export const addClass = (el: HTMLElement, className: string) => {
+  if (!el) return;
+
   if (el.classList) {
     el.classList.add(className);
   } else {
@@ -11,6 +13,8 @@ export const addClass = (el: HTMLElement, className: string) => {
 };
 
 export const removeClass = (el: HTMLElement, className: string) => {
+  if (!el) return;
+
   if (el.classList) {
     el.classList.remove(className);
   } else {

--- a/test/manual/js/pagination.js
+++ b/test/manual/js/pagination.js
@@ -58,3 +58,11 @@ const applyBulletSize = (newIndex, ctx) => {
     bullet.style.transform = "";
   });
 };
+
+document.querySelector("#remove").addEventListener("click", () => {
+  flicking.remove(0, flicking.panelCount);
+});
+
+document.querySelector("#add").addEventListener("click", () => {
+  flicking.append(`<div class="card mr-2"></div>`);
+});

--- a/test/manual/pagination.html
+++ b/test/manual/pagination.html
@@ -28,6 +28,8 @@
           </div>
           <div class="flicking-pagination"></div>
         </div>
+        <button id="remove">REMOVE</button>
+        <button id="add">ADD</button>
         <h1 class="title has-text-dark my-4">Pagination - Fraction</h1>
         <div id="pagination-number" class="flicking-viewport p-2">
           <div class="flicking-camera">

--- a/test/unit/Pagination.spec.ts
+++ b/test/unit/Pagination.spec.ts
@@ -1,25 +1,58 @@
 import Flicking from "@egjs/flicking";
 import Pagination from "../../src/pagination/Pagination";
-import { createFlickingFixture } from "./utils";
+import { cleanup, createFlicking, createFlickingFixture, createPaginationFixture, sandbox } from "./utils";
 
 describe("Pagination", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  const createFixture = () => {
+    const fixtureWrapper = sandbox("pagination");
+    const fixture = createPaginationFixture();
+    fixtureWrapper.appendChild(fixture);
+
+    return fixture;
+  };
+
   describe("Options", () => {
     describe("renderBullet", () => {
       it("should not remove custom classes when the 'scroll' type is used", () => {
         // Given
-        const flicking = new Flicking(createFlickingFixture());
+        const flicking = new Flicking(createFixture());
         const pagination = new Pagination({
           renderBullet: (className: string) => `<span class="${className} test"></span>`,
           type: "scroll"
         });
 
         // When
-        flicking.addPlugins(pagination);
+        pagination.init(flicking);
 
         // Then
         const bullets = [].slice.apply(document.querySelectorAll(".flicking-pagination-bullet"));
         expect(bullets.every(bullet => bullet.classList.contains("test"))).to.be.true;
       });
+    });
+  });
+
+  describe("Index change", () => {
+    it("should not throw any error while Flicking is replacing all panels", async () => {
+      // Given
+      const flicking = await createFlicking(createFixture());
+      const pagination = new Pagination({
+        renderBullet: (className: string) => `<span class="${className} test"></span>`,
+        type: "bullet"
+      });
+
+      // When
+      pagination.init(flicking);
+      flicking.remove(0, flicking.panelCount);
+      flicking.append(document.createElement("div"));
+
+      // Then
+      // There should be one active bullet selected
+      const bullets = [].slice.apply(document.querySelectorAll(".flicking-pagination-bullet-active"));
+      expect(bullets.length).to.equal(1);
     });
   });
 });

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -49,6 +49,27 @@ export const createFlickingFixture = () => {
   return viewport;
 };
 
+export const createPaginationFixture = () => {
+  const defaultFixture = createFlickingFixture();
+  const paginationWrapper = document.createElement("div");
+
+  paginationWrapper.className = "flicking-pagination";
+  defaultFixture.appendChild(paginationWrapper);
+
+  return defaultFixture;
+};
+
+export const createFlicking = async (el: HTMLElement, option: ConstructorParameters<typeof Flicking>[1] = {}): Promise<Flicking> => {
+  const flicking = new Flicking(el, option);
+
+  if (!flicking.autoInit) return Promise.resolve(flicking);
+
+  return new Promise(resolve => {
+    flicking.once(EVENTS.READY, () => resolve(flicking));
+  });
+};
+
+
 export const simulate = (el: HTMLElement, option: Partial<{
   pos: [number, number];
   deltaX: number;


### PR DESCRIPTION
## Issue
https://github.com/naver/egjs-flicking/issues/614

## Details
This fixes pagination throws an error on panel change due to the index change triggered before it.