### PR TITLE
feat: add perspective plugin

### DIFF
--- a/src/Fade.ts
+++ b/src/Fade.ts
@@ -48,6 +48,7 @@ class Fade implements Plugin {
     if (!this._flicking) return;
 
     this._flicking.off(EVENTS.MOVE, this._onMove);
+    this._flicking.off(EVENTS.AFTER_RESIZE, this.update);
     this._flicking = null;
   }
 

--- a/src/Parallax.ts
+++ b/src/Parallax.ts
@@ -48,6 +48,7 @@ class Parallax implements Plugin {
     if (!this._flicking) return;
 
     this._flicking.off(EVENTS.MOVE, this._onMove);
+    this._flicking.off(EVENTS.AFTER_RESIZE, this.update);
     this._flicking = null;
   }
 

--- a/src/Perspective.ts
+++ b/src/Perspective.ts
@@ -1,0 +1,101 @@
+/* eslint-disable no-underscore-dangle */
+import Flicking, { EVENTS, Plugin } from "@egjs/flicking";
+
+interface PerspectiveOptions {
+  selector: string;
+  scale: number;
+  rotate: number;
+  perspective: number;
+}
+
+/**
+ * You can apply perspective effect while panel is moving.
+ * @ko 패널들을 움직이면서 입체감을 부여할 수 있습니다.
+ * @memberof Flicking.Plugins
+ */
+class Perspective implements Plugin {
+  private _flicking: Flicking | null;
+
+  /* Options  */
+  private _selector: PerspectiveOptions["selector"];
+  private _scale: PerspectiveOptions["scale"];
+  private _rotate: PerspectiveOptions["rotate"];
+  private _perspective: PerspectiveOptions["perspective"];
+
+  public get selector() { return this._selector; }
+  public get scale() { return this._scale; }
+  public get rotate() { return this._rotate; }
+  public get perspective() { return this._perspective; }
+
+  public set selector(val: string) { this._selector = val; }
+  public set scale(val: number) { this._scale = val; }
+  public set rotate(val: number) { this._rotate = val; }
+  public set perspective(val: number) { this._perspective = val; }
+
+  /**
+   * @param - The selector of the element to which the perspective effect is to be applied. If the selector is blank, it applies to panel element. <ko>입체 효과를 적용할 대상의 선택자. 선택자가 공백이면 패널 엘리먼트에 적용된다.</ko>
+   * @param - Effect amplication scale.<ko>효과 증폭도</ko>
+   * @param - Effect amplication rotate.<ko>회전 증폭도</ko>
+   * @param - The value of perspective CSS property. <ko>css perspective 속성 값</ko>
+   * @example
+   * ```ts
+   * flicking.addPlugins(new Perspective({ selector: "p", scale: 1, rotate: 1, perspective = 1000 }));
+   * ```
+   */
+  public constructor({ selector = "", scale = 1, rotate = 1, perspective = 1000 }: Partial<PerspectiveOptions> = {}) {
+    this._flicking = null;
+    this._selector = selector;
+    this._scale = scale;
+    this._rotate = rotate;
+    this._perspective = perspective;
+  }
+
+  public init(flicking: Flicking): void {
+    if (this._flicking) {
+      this.destroy();
+    }
+
+    this._flicking = flicking;
+
+    flicking.on(EVENTS.MOVE, this._onMove);
+    flicking.on(EVENTS.AFTER_RESIZE, this.update);
+    this._onMove();
+  }
+
+  public destroy(): void {
+    if (!this._flicking) return;
+
+    this._flicking.off(EVENTS.MOVE, this._onMove);
+    this._flicking = null;
+  }
+
+  public update = (): void => {
+    this._onMove();
+  };
+
+  private _onMove = (): void => {
+    const flicking = this._flicking;
+    const selector = this._selector;
+    const scale = this._scale;
+    const rotate =  this._rotate;
+    const perspective = this._perspective;
+
+    if (!flicking) return;
+
+    const horizontal = flicking.horizontal;
+    const panels = flicking.visiblePanels;
+
+    panels.forEach((panel) => {
+      const progress = panel.outsetProgress;
+      const el = panel.element;
+      const target = selector ? el.querySelector<HTMLElement>(selector)! : el;
+      const panelScale = 1 / (Math.abs(progress * scale) + 1);
+      const rotateDegree = progress > 0 ? Math.min(90, progress * 100 * rotate) : Math.max(-90, progress * 100 * rotate);
+      const [rotateX, rotateY] = horizontal ? [0, rotateDegree] : [rotateDegree, 0];
+
+      target.style.transform = `perspective(${perspective}px) rotateX(${rotateX}deg) rotateY(${rotateY}deg) scale(${panelScale})`;
+    });
+  };
+}
+
+export default Perspective;

--- a/src/Perspective.ts
+++ b/src/Perspective.ts
@@ -66,6 +66,7 @@ class Perspective implements Plugin {
     if (!this._flicking) return;
 
     this._flicking.off(EVENTS.MOVE, this._onMove);
+    this._flicking.off(EVENTS.AFTER_RESIZE, this.update);
     this._flicking = null;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import Fade from "./Fade";
 import AutoPlay from "./AutoPlay";
 import Arrow from "./Arrow";
 import Sync, { SyncOptions, SychronizableFlickingOptions } from "./Sync";
+import Perspective from "./Perspective";
 
 export * from "./pagination";
 
@@ -17,7 +18,8 @@ export {
   Fade,
   AutoPlay,
   Arrow,
-  Sync
+  Sync,
+  Perspective
 };
 
 export type {

--- a/test/manual/js/perspective.js
+++ b/test/manual/js/perspective.js
@@ -1,6 +1,6 @@
 const flicking = new Flicking("#perspective");
 
 // Perspective
-const perspective = new Flicking.Plugins.Perspective({});
+const perspective = new Flicking.Plugins.Perspective();
 flicking.addPlugins(perspective)
 

--- a/test/manual/js/perspective.js
+++ b/test/manual/js/perspective.js
@@ -1,0 +1,6 @@
+const flicking = new Flicking("#perspective");
+
+// Perspective
+const perspective = new Flicking.Plugins.Perspective({});
+flicking.addPlugins(perspective)
+

--- a/test/manual/perspective.html
+++ b/test/manual/perspective.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta name="viewport"
+        content="width=device-width,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0,user-scalable=no,target-densitydpi=medium-dpi">
+    <script src="../../node_modules/@egjs/flicking/dist/flicking.pkgd.js"></script>
+    <script src="../../dist/plugins.js"></script>
+    <link rel="stylesheet" href="../../node_modules/@egjs/flicking/dist/flicking.css">
+    <link rel="stylesheet" href="../../node_modules/bulma/css/bulma.min.css">
+    <link rel="stylesheet" href="./css/common.css">
+</head>
+
+<body>
+    <div class="container">
+        <h1 class="title has-text-dark my-4">Perspective</h1>
+        <div id="perspective" class="flicking-viewport p-2">
+            <div class="flicking-camera">
+                <div class="card mr-2"></div>
+                <div class="card mr-2"></div>
+                <div class="card mr-2"></div>
+                <div class="card mr-2"></div>
+                <div class="card mr-2"></div>
+                <div class="card mr-2"></div>
+                <div class="card mr-2"></div>
+                <div class="card mr-2"></div>
+                <div class="card mr-2"></div>
+                <div class="card mr-2"></div>
+            </div>
+        </div>
+    </div>
+    <script src="./js/perspective.js"></script>
+</body>
+
+</html>

--- a/test/unit/Perspective.spec.ts
+++ b/test/unit/Perspective.spec.ts
@@ -9,7 +9,7 @@ describe("Perspective", () => {
   beforeEach(() => {
     const wrapper = sandbox("flick");
     wrapper.style.width = "199px";
-    wrapper.className = "flicking-viewport";
+    wrapper.classList.add("flicking-viewport");
     wrapper.innerHTML = `
       <div class="flicking-camera">
         <div style="width: 200px; height: 200px;"><p></p></div>

--- a/test/unit/Perspective.spec.ts
+++ b/test/unit/Perspective.spec.ts
@@ -1,0 +1,78 @@
+import Flicking from "@egjs/flicking";
+
+import Perspective from "../../src/Perspective";
+import { sandbox, cleanup, waitEvent } from "../unit/utils";
+
+describe("Perspective", () => {
+  let flicking: Flicking;
+
+  beforeEach(() => {
+    const wrapper = sandbox("flick");
+    wrapper.style.width = "199px";
+    wrapper.className = "flicking-viewport";
+    wrapper.innerHTML = `
+      <div class="flicking-camera">
+        <div style="width: 200px; height: 200px;"><p></p></div>
+        <div style="width: 200px; height: 200px;"><p></p></div>
+        <div style="width: 200px; height: 200px;"><p></p></div>
+      </div>
+    `;
+    flicking = new Flicking(wrapper);
+  });
+
+  afterEach(() => {
+    cleanup();
+    flicking.destroy();
+  });
+
+  it("should set transform to default for current panel", async () => {
+    // Given & When
+    flicking.addPlugins(new Perspective());
+    await waitEvent(flicking, "ready");
+
+    // Then
+    expect(flicking.currentPanel.element.style.transform).to.equal("perspective(1000px) rotateX(0deg) rotateY(0deg) scale(1)");
+  });
+
+  it("should set transform to default that except perspective for current panel when allocated other arguments", async () => {
+    // Given & When
+    flicking.addPlugins(new Perspective({perspective: 500, rotate: 0.5, scale: 0.5}));
+    await waitEvent(flicking, "ready");
+
+    // Then
+    expect(flicking.currentPanel.element.style.transform).to.equal("perspective(500px) rotateX(0deg) rotateY(0deg) scale(1)");
+  });
+
+  it("should apply transform to child elements if a selector is given", async () => {
+    // Given & When
+    flicking.addPlugins(new Perspective({selector: "p"}));
+    await waitEvent(flicking, "ready");
+
+    // Then
+    const currentPanelEl = flicking.currentPanel.element;
+
+    expect(currentPanelEl.style.transform).to.equal("");
+    expect(currentPanelEl.querySelector("p").style.transform).to.equal("perspective(1000px) rotateX(0deg) rotateY(0deg) scale(1)");
+  });
+
+  it("should not set transform for invisible panels", () => {
+    // Given & When
+    flicking.addPlugins(new Perspective());
+
+    // Then
+    expect(flicking.getPanel(1).element.style.transform).to.equal("");
+    expect(flicking.getPanel(2).element.style.transform).to.equal("");
+  });
+
+  it("should be updated whenever flicking moves", async () => {
+    // Given
+    flicking.addPlugins(new Perspective());
+    await waitEvent(flicking, "ready");
+
+    // When
+    void flicking.moveTo(1, 0);
+
+    // Then
+    expect(flicking.getPanel(1).element.style.transform).to.equal("perspective(1000px) rotateX(0deg) rotateY(0deg) scale(1)");
+  });
+});


### PR DESCRIPTION
## Details

1. 3D 입체감을 부여할 수 있는 perspective plugin입니다.
    It is a perspective plugin that can give a 3D three-dimensional effect.
2. scale을 활용하여 상대적 크기, rotate를 활용하여 회전크기, perspective를 활용하여 z축 시야를 조절할 수 있습니다.
   You can adjust the relative size using scale, adjust the rotational size using rotate, and adjust the z-axis field of view using perspective.
