### PR TITLE
feat: add animationDuration option to AutoPlay

### DIFF
--- a/src/AutoPlay.ts
+++ b/src/AutoPlay.ts
@@ -2,6 +2,7 @@ import Flicking, { EVENTS, Plugin, DIRECTION } from "@egjs/flicking";
 
 interface AutoPlayOptions {
   duration: number;
+  animationDuration: number | undefined;
   direction: typeof DIRECTION["NEXT"] | typeof DIRECTION["PREV"];
   stopOnHover: boolean;
 }
@@ -14,6 +15,7 @@ interface AutoPlayOptions {
 class AutoPlay implements Plugin {
   /* Options */
   private _duration: AutoPlayOptions["duration"];
+  private _animationDuration: AutoPlayOptions["animationDuration"];
   private _direction: AutoPlayOptions["direction"];
   private _stopOnHover: AutoPlayOptions["stopOnHover"];
 
@@ -23,16 +25,19 @@ class AutoPlay implements Plugin {
   private _mouseEntered = false;
 
   public get duration() { return this._duration; }
+  public get animationDuration() { return this._animationDuration; }
   public get direction() { return this._direction; }
   public get stopOnHover() { return this._stopOnHover; }
 
   public set duration(val: number) { this._duration = val; }
+  public set animationDuration(val: number | undefined) { this._animationDuration = val; }
   public set direction(val: AutoPlayOptions["direction"]) { this._direction = val; }
   public set stopOnHover(val: boolean) { this._stopOnHover = val; }
 
   /**
    * @param {AutoPlayOptions} options Options for the AutoPlay instance.<ko>AutoPlay 옵션</ko>
    * @param {number} options.duration Time to wait before moving on to the next panel.<ko>다음 패널로 움직이기까지 대기 시간</ko>
+   * @param {number | undefined} options.animationDuration Duration of animation of moving to the next panel.<ko>패널이 움직이는 애니메이션의 지속 시간</ko>
    * @param {"PREV" | "NEXT"} options.direction The direction in which the panel moves.<ko>패널이 움직이는 방향</ko>
    * @param {boolean} options.stopOnHover Whether to stop when mouse hover upon the element.<ko>엘리먼트에 마우스를 올렸을 때 AutoPlay를 정지할지 여부</ko>
    * @example
@@ -42,10 +47,12 @@ class AutoPlay implements Plugin {
    */
   public constructor({
     duration = 2000,
+    animationDuration = undefined,
     direction = DIRECTION.NEXT,
     stopOnHover = false
   }: Partial<AutoPlayOptions> = {}) {
     this._duration = duration;
+    this._animationDuration = animationDuration;
     this._direction = direction;
     this._stopOnHover = stopOnHover;
   }
@@ -114,9 +121,9 @@ class AutoPlay implements Plugin {
 
     this._timerId = window.setTimeout(() => {
       if (direction === DIRECTION.NEXT) {
-        flicking.next().catch(() => void 0);
+        flicking.next(this._animationDuration).catch(() => void 0);
       } else {
-        flicking.prev().catch(() => void 0);
+        flicking.prev(this._animationDuration).catch(() => void 0);
       }
 
       this.play();

--- a/src/AutoPlay.ts
+++ b/src/AutoPlay.ts
@@ -37,7 +37,7 @@ class AutoPlay implements Plugin {
   /**
    * @param {AutoPlayOptions} options Options for the AutoPlay instance.<ko>AutoPlay 옵션</ko>
    * @param {number} options.duration Time to wait before moving on to the next panel.<ko>다음 패널로 움직이기까지 대기 시간</ko>
-   * @param {number | undefined} options.animationDuration Duration of animation of moving to the next panel.<ko>패널이 움직이는 애니메이션의 지속 시간</ko>
+   * @param {number | undefined} options.animationDuration Duration of animation of moving to the next panel. If undefined, duration option of the Flicking instance is used instead.<ko>패널이 움직이는 애니메이션의 지속 시간, undefined라면 Flicking 인스턴스의 duration 값을 사용한다</ko>
    * @param {"PREV" | "NEXT"} options.direction The direction in which the panel moves.<ko>패널이 움직이는 방향</ko>
    * @param {boolean} options.stopOnHover Whether to stop when mouse hover upon the element.<ko>엘리먼트에 마우스를 올렸을 때 AutoPlay를 정지할지 여부</ko>
    * @example

--- a/test/unit/AutoPlay.spec.ts
+++ b/test/unit/AutoPlay.spec.ts
@@ -48,6 +48,25 @@ describe("AutoPlay", () => {
     expect(nextStub.calledOnce).to.be.true;
   });
 
+  it("should apply animationDuration to animation when moving panel", async () => {
+    // Given
+    const plugin = new AutoPlay({ direction: "NEXT", duration: 500, animationDuration: 200 });
+    const flicking = new Flicking(createFlickingFixture());
+    const changedSpy = sinon.spy();
+    flicking.on("changed", changedSpy);
+
+    // When
+    flicking.addPlugins(plugin);
+    await waitEvent(flicking, "ready");
+
+    // Then
+    expect(changedSpy.called).to.be.false;
+    tick(600);
+    expect(changedSpy.called).to.be.false;
+    tick(500);
+    expect(changedSpy.calledOnce).to.be.true;
+  });
+
   it("can stop autoplay if stop is called before duration", () => {
     // Given
     const plugin = new AutoPlay({ direction: "NEXT", duration: 500 });

--- a/test/unit/AutoPlay.spec.ts
+++ b/test/unit/AutoPlay.spec.ts
@@ -51,37 +51,18 @@ describe("AutoPlay", () => {
   it("should apply animationDuration to animation when moving panel", async () => {
     // Given
     const plugin = new AutoPlay({ direction: "NEXT", duration: 500, animationDuration: 200 });
-    const wrapper = sandbox("flick0");
-    const viewportEl = document.createElement("div");
-    viewportEl.innerHTML = `
-      <div class="flicking-camera">
-        <div style="width: 200px; height: 200px;"><p></p></div>
-        <div style="width: 200px; height: 200px;"><p></p></div>
-        <div style="width: 200px; height: 200px;"><p></p></div>
-      </div>
-    `;
-    wrapper.appendChild(viewportEl);
-    const flicking = new Flicking(viewportEl);
-    const moveStartSpy = sinon.spy();
-    const moveEndSpy = sinon.spy();
-    flicking.on(EVENTS.MOVE_START, moveStartSpy);
-    flicking.on(EVENTS.MOVE_END, moveEndSpy);
+    const flicking = new Flicking(createFlickingFixture());
+    const nextSpy = sinon.spy(flicking, "next");
 
     // When
     flicking.addPlugins(plugin);
     await waitEvent(flicking, "ready");
 
     // Then
-    expect(moveStartSpy.called).to.be.false;
-    expect(moveEndSpy.called).to.be.false;
-    tick(600);
-    expect(moveStartSpy.calledOnce).to.be.true;
-    expect(moveEndSpy.called).to.be.false;
+    expect(nextSpy.called).to.be.false;
     tick(500);
-    expect(moveStartSpy.calledOnce).to.be.true;
-    expect(moveEndSpy.calledOnce).to.be.true;
-    cleanup();
-    flicking.destroy();
+    expect(nextSpy.calledOnce).to.be.true;
+    expect(nextSpy.firstCall.calledWith(200)).to.be.true;
   });
 
   it("can stop autoplay if stop is called before duration", () => {


### PR DESCRIPTION
## Issue
#42 

## Details
This adds `animationDuration` option which determines the duration of the animation that the panel moves by `AutoPlay` plugin.
