### PR TITLE
feat: add delayAfterHover option to AutoPlay

### DIFF
--- a/src/AutoPlay.ts
+++ b/src/AutoPlay.ts
@@ -65,8 +65,8 @@ class AutoPlay implements Plugin {
     flicking.on({
       [EVENTS.MOVE_START]: this.stop,
       [EVENTS.HOLD_START]: this.stop,
-      [EVENTS.MOVE_END]: this._move,
-      [EVENTS.SELECT]: this._move
+      [EVENTS.MOVE_END]: this.play,
+      [EVENTS.SELECT]: this.play
     });
 
     this._flicking = flicking;
@@ -91,8 +91,8 @@ class AutoPlay implements Plugin {
 
     flicking.off(EVENTS.MOVE_START, this.stop);
     flicking.off(EVENTS.HOLD_START, this.stop);
-    flicking.off(EVENTS.MOVE_END, this._move);
-    flicking.off(EVENTS.SELECT, this._move);
+    flicking.off(EVENTS.MOVE_END, this.play);
+    flicking.off(EVENTS.SELECT, this.play);
 
     const targetEl = flicking.element;
     targetEl.removeEventListener("mouseenter", this._onMouseEnter, false);
@@ -105,7 +105,15 @@ class AutoPlay implements Plugin {
     // DO-NOTHING
   }
 
-  public play = (duration?: number) => {
+  public play = () => {
+    this._movePanel(this._duration);
+  };
+
+  public stop = () => {
+    clearTimeout(this._timerId);
+  };
+
+  private _movePanel(duration: number): void {
     const flicking = this._flicking;
     const direction = this._direction;
 
@@ -127,16 +135,8 @@ class AutoPlay implements Plugin {
       }
 
       this.play();
-    }, duration ?? this._duration);
-  };
-
-  public stop = () => {
-    clearTimeout(this._timerId);
-  };
-
-  private _move = () => {
-    this.play();
-  };
+    }, duration);
+  }
 
   private _onMouseEnter = () => {
     this._mouseEntered = true;
@@ -145,7 +145,7 @@ class AutoPlay implements Plugin {
 
   private _onMouseLeave = () => {
     this._mouseEntered = false;
-    this.play(this._delayAfterHover);
+    this._movePanel(this._delayAfterHover);
   };
 }
 

--- a/test/manual/autoplay.html
+++ b/test/manual/autoplay.html
@@ -3,9 +3,9 @@
     <head>
         <title>Flicking plugins test page</title>
         <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0,user-scalable=no,target-densitydpi=medium-dpi">
-        <script src="../node_modules/@egjs/flicking/dist/flicking.pkgd.js"></script>
-        <script src="../dist/plugins.js"></script>
-        <link rel="stylesheet" href="../node_modules/@egjs/flicking/dist/flicking.css">
+        <script src="../../node_modules/@egjs/flicking/dist/flicking.pkgd.js"></script>
+        <script src="../../dist/plugins.js"></script>
+        <link rel="stylesheet" href="../../node_modules/@egjs/flicking/dist/flicking.css">
         <link rel="stylesheet" href="./css/common.css">
     </head>
     <body>

--- a/test/unit/AutoPlay.spec.ts
+++ b/test/unit/AutoPlay.spec.ts
@@ -106,6 +106,36 @@ describe("AutoPlay", () => {
     expect(playSpy.calledTwice).to.be.true;
   });
 
+  it("should call next after delayAfterHover milliseconds when mouse leaved and stopOnHover is true", async () => {
+    // Given
+    const plugin = new AutoPlay({
+      direction: "NEXT",
+      duration: 1000,
+      stopOnHover: true,
+      delayAfterHover: 500
+    });
+    const flicking = new Flicking(createFlickingFixture());
+    const nextStub = sinon.stub(flicking, "next");
+
+    nextStub.resolves(void 0);
+
+    // When
+    flicking.addPlugins(plugin);
+    await waitEvent(flicking, "ready");
+    const wrapper = flicking.element;
+
+    // Then
+    expect(nextStub.called).to.be.false;
+    tick(1200);
+    expect(nextStub.calledOnce).to.be.true;
+    wrapper.dispatchEvent(new Event("mouseenter"));
+    tick(1200);
+    expect(nextStub.calledOnce).to.be.true;
+    wrapper.dispatchEvent(new Event("mouseleave"));
+    tick(700);
+    expect(nextStub.calledTwice).to.be.true;
+  });
+
   it("should detach flicking event handlers when destroyed", () => {
     // Given
     const plugin = new AutoPlay({ stopOnHover: true });


### PR DESCRIPTION
## Details
This adds `delayAfterHover` option to AutoPlay plugin, which determines the amount of time to wait before moving on to the next panel when mouse leaves the element and `stopOnHover` is true.
For example, when `duration` is set to 3000 and `delayAfterHover` is set to 1000, panel will move to next index after 1000 milliseconds after mouse leaves the element.
Also when `duration` is set to 3000 and `delayAfterHover` is set to 5000, panel will move to next index after 5000 milliseconds after mouse leaves the element.

