### PR TITLE
fix: fade plugin when using renderOnlyVisible

### DIFF
--- a/src/Fade.ts
+++ b/src/Fade.ts
@@ -71,7 +71,9 @@ class Fade implements Plugin {
       const target = selector ? el.querySelector<HTMLElement>(selector)! : el;
       const opacity = Math.min(1, Math.max(0, (1 - Math.abs(progress * scale))));
 
-      target.style.opacity = `${opacity}`;
+      if(target) {
+        target.style.opacity = `${opacity}`;
+      }
     });
   };
 }

--- a/src/Fade.ts
+++ b/src/Fade.ts
@@ -69,9 +69,9 @@ class Fade implements Plugin {
       const progress = panel.outsetProgress;
       const el = panel.element;
       const target = selector ? el.querySelector<HTMLElement>(selector)! : el;
-      const opacity = Math.min(1, Math.max(0, (1 - Math.abs(progress * scale))));
 
-      if(target) {
+      if (target) {
+        const opacity = Math.min( 1, Math.max(0, 1 - Math.abs(progress * scale)));
         target.style.opacity = `${opacity}`;
       }
     });


### PR DESCRIPTION
## Details
<!-- Detailed description of the change/feature -->
Fix error "Uncaught TypeError: Cannot read properties of null (reading 'style')" when using renderOnlyVisible set to true
