### PR TITLE
feat: add renderActiveBullet

### DIFF
--- a/src/pagination/Pagination.ts
+++ b/src/pagination/Pagination.ts
@@ -16,6 +16,7 @@ export interface PaginationOptions {
   bulletCount: number;
   renderBullet: (className: string, index: number) => string;
   renderFraction: (currentClass: string, totalClass: string) => string;
+  renderActiveBullet: ((className: string, index: number) => string) | null;
   fractionCurrentFormat: (index: number) => string;
   fractionTotalFormat: (total: number) => string;
   scrollOnChange: (index: number, ctx: ScrollContext) => any;
@@ -37,6 +38,7 @@ class Pagination implements Plugin {
   private _classPrefix: PaginationOptions["classPrefix"];
   private _bulletCount: PaginationOptions["bulletCount"];
   private _renderBullet: PaginationOptions["renderBullet"];
+  private _renderActiveBullet: PaginationOptions["renderActiveBullet"];
   private _renderFraction: PaginationOptions["renderFraction"];
   private _fractionCurrentFormat: PaginationOptions["fractionCurrentFormat"];
   private _fractionTotalFormat: PaginationOptions["fractionTotalFormat"];
@@ -48,6 +50,7 @@ class Pagination implements Plugin {
   public get classPrefix() { return this._classPrefix; }
   public get bulletCount() { return this._bulletCount; }
   public get renderBullet() { return this._renderBullet; }
+  public get renderActiveBullet() { return this._renderActiveBullet; }
   public get renderFraction() { return this._renderFraction; }
   public get fractionCurrentFormat() { return this._fractionCurrentFormat; }
   public get fractionTotalFormat() { return this._fractionTotalFormat; }
@@ -59,6 +62,7 @@ class Pagination implements Plugin {
   public set bulletWrapperclassPrefixClass(val: PaginationOptions["classPrefix"]) { this._classPrefix = val; }
   public set bulletCount(val: PaginationOptions["bulletCount"]) { this._bulletCount = val; }
   public set renderBullet(val: PaginationOptions["renderBullet"]) { this._renderBullet = val; }
+  public set renderActiveBullet(val: PaginationOptions["renderActiveBullet"]) { this._renderActiveBullet = val; }
   public set renderFraction(val: PaginationOptions["renderFraction"]) { this._renderFraction = val; }
   public set fractionCurrentFormat(val: PaginationOptions["fractionCurrentFormat"]) { this._fractionCurrentFormat = val; }
   public set fractionTotalFormat(val: PaginationOptions["fractionTotalFormat"]) { this._fractionTotalFormat = val; }
@@ -71,6 +75,7 @@ class Pagination implements Plugin {
     classPrefix = PAGINATION.PREFIX,
     bulletCount = 5,
     renderBullet = (className: string) => `<span class="${className}"></span>`,
+    renderActiveBullet = null,
     renderFraction = (currentClass: string, totalClass: string) => `<span class="${currentClass}"></span>/<span class="${totalClass}"></span>`,
     fractionCurrentFormat = (index: number) => index.toString(),
     fractionTotalFormat = (index: number) => index.toString(),
@@ -82,6 +87,7 @@ class Pagination implements Plugin {
     this._classPrefix = classPrefix;
     this._bulletCount = bulletCount;
     this._renderBullet = renderBullet;
+    this._renderActiveBullet = renderActiveBullet;
     this._renderFraction = renderFraction;
     this._fractionCurrentFormat = fractionCurrentFormat;
     this._fractionTotalFormat = fractionTotalFormat;
@@ -125,6 +131,7 @@ class Pagination implements Plugin {
     flicking.off(EVENTS.WILL_RESTORE, this._onIndexChange);
     flicking.off(EVENTS.PANEL_CHANGE, this.update);
 
+    this._renderer.destroy();
     this._removeAllChilds();
     this._flicking = null;
   }

--- a/src/pagination/index.ts
+++ b/src/pagination/index.ts
@@ -1,6 +1,9 @@
-import Pagination from "./Pagination";
+import Pagination, { PaginationOptions } from "./Pagination";
 
-export * from "./renderer";
 export {
   Pagination
+};
+
+export type {
+  PaginationOptions
 };

--- a/src/pagination/renderer/BulletRenderer.ts
+++ b/src/pagination/renderer/BulletRenderer.ts
@@ -88,7 +88,7 @@ class BulletRenderer extends Renderer {
           prevIndex
         );
         prevBullet.parentElement!.replaceChild(newBullet, prevBullet);
-        bullets.splice(prevIndex, 1, newBullet);
+        bullets[prevIndex] = newBullet;
       }
 
       const activeBullet = bullets[activeBulletIndex];
@@ -98,7 +98,7 @@ class BulletRenderer extends Renderer {
       );
 
       wrapper.replaceChild(newActiveBullet, activeBullet);
-      bullets.splice(activeBulletIndex, 1, newActiveBullet);
+      bullets[activeBulletIndex] = newActiveBullet;
     } else {
       const activeBullet = bullets[activeBulletIndex];
       const prevBullet = bullets[prevIndex];

--- a/src/pagination/renderer/FractionRenderer.ts
+++ b/src/pagination/renderer/FractionRenderer.ts
@@ -4,6 +4,14 @@ import { addClass } from "../../utils";
 import Renderer from "./Renderer";
 
 class FractionRenderer extends Renderer {
+  private _prevIndex: number = -1;
+  private _prevTotal: number = -1;
+
+  public destroy(): void {
+    this._prevIndex = -1;
+    this._prevTotal = -1;
+  }
+
   public render() {
     const flicking = this._flicking;
     const wrapper = this._wrapper;
@@ -23,19 +31,26 @@ class FractionRenderer extends Renderer {
     const flicking = this._flicking;
     const wrapper = this._wrapper;
     const pagination = this._pagination;
-    const fractionCurrentClass = `${pagination.classPrefix}-${PAGINATION.FRACTION_CURRENT_SUFFIX}`;
-    const fractionTotalClass = `${pagination.classPrefix}-${PAGINATION.FRACTION_TOTAL_SUFFIX}`;
 
-    const currentWrapper = wrapper.querySelector(`.${fractionCurrentClass}`) as HTMLElement;
-    const totalWrapper = wrapper.querySelector(`.${fractionTotalClass}`) as HTMLElement;
     const anchorPoints = flicking.camera.anchorPoints;
-
     const currentIndex = anchorPoints.length > 0
       ? index - anchorPoints[0].panel.index + 1
       : 0;
+    const anchorCount = anchorPoints.length;
+
+    if (currentIndex === this._prevIndex && anchorCount === this._prevTotal) return;
+
+    const fractionCurrentSelector = `.${pagination.classPrefix}-${PAGINATION.FRACTION_CURRENT_SUFFIX}`;
+    const fractionTotalSelector = `.${pagination.classPrefix}-${PAGINATION.FRACTION_TOTAL_SUFFIX}`;
+
+    const currentWrapper = wrapper.querySelector(fractionCurrentSelector) as HTMLElement;
+    const totalWrapper = wrapper.querySelector(fractionTotalSelector) as HTMLElement;
 
     currentWrapper.innerHTML = pagination.fractionCurrentFormat(currentIndex);
-    totalWrapper.innerHTML = pagination.fractionTotalFormat(anchorPoints.length);
+    totalWrapper.innerHTML = pagination.fractionTotalFormat(anchorCount);
+
+    this._prevIndex = currentIndex;
+    this._prevTotal = anchorCount;
   }
 }
 

--- a/src/pagination/renderer/Renderer.ts
+++ b/src/pagination/renderer/Renderer.ts
@@ -1,5 +1,6 @@
-import Flicking from "@egjs/flicking";
+import Flicking, { FlickingError } from "@egjs/flicking";
 
+import { BROWSER } from "../../event";
 import Pagination from "../Pagination";
 
 export interface RendererOptions {
@@ -23,8 +24,40 @@ abstract class Renderer {
     this._wrapper = wrapper;
   }
 
+  public abstract destroy(): void;
   public abstract render(): void;
   public abstract update(index: number): void;
+
+  protected _createBulletFromString(html: string, index: number) {
+    const range = document.createRange();
+    const frag = range.createContextualFragment(html);
+    const bullet = frag.firstChild as HTMLElement;
+
+    this._addBulletEvents(bullet, index);
+
+    return bullet;
+  }
+
+  protected _addBulletEvents(bullet: HTMLElement, index: number) {
+    const anchorPoints = this._flicking.camera.anchorPoints;
+    const panelIndex = anchorPoints[index].panel.index;
+
+    bullet.addEventListener(BROWSER.MOUSE_DOWN, e => {
+      e.stopPropagation();
+    });
+
+    bullet.addEventListener(BROWSER.TOUCH_START, e => {
+      e.stopPropagation();
+    }, { passive: true });
+
+    bullet.addEventListener(BROWSER.CLICK, () => {
+      this._flicking.moveTo(panelIndex)
+        .catch(err => {
+          if (err instanceof FlickingError) return;
+          throw err;
+        });
+    });
+  }
 }
 
 export default Renderer;

--- a/src/pagination/renderer/ScrollBulletRenderer.ts
+++ b/src/pagination/renderer/ScrollBulletRenderer.ts
@@ -98,7 +98,7 @@ class ScrollBulletRenderer extends Renderer {
           prevIndex
         );
         prevBullet.parentElement!.replaceChild(newBullet, prevBullet);
-        bullets.splice(prevIndex, 1, newBullet);
+        bullets[prevIndex] = newBullet;
       }
 
       const activeBullet = bullets[activeIndex];
@@ -109,7 +109,7 @@ class ScrollBulletRenderer extends Renderer {
         );
 
         activeBullet.parentElement!.replaceChild(newActiveBullet, activeBullet);
-        bullets.splice(activeIndex, 1, newActiveBullet);
+        bullets[activeIndex] = newActiveBullet;
       }
     }
 

--- a/src/pagination/renderer/index.ts
+++ b/src/pagination/renderer/index.ts
@@ -1,5 +1,0 @@
-import Renderer from "./Renderer";
-
-export type {
-  Renderer
-};

--- a/test/manual/js/pagination.js
+++ b/test/manual/js/pagination.js
@@ -2,6 +2,13 @@ const flicking = new Flicking("#pagination", { bound: true });
 
 flicking.addPlugins(new Flicking.Plugins.Pagination());
 
+const flicking1_1 = new Flicking("#pagination2", { bound: true });
+
+flicking1_1.addPlugins(new Flicking.Plugins.Pagination({
+  renderBullet: (className, index) => `<span class="${className}">${index + 1}</span>`,
+  renderActiveBullet: (className) => `<span class="${className}"></span>`
+}));
+
 const flicking2 = new Flicking("#pagination-number");
 
 flicking2.addPlugins(new Flicking.Plugins.Pagination({ type: "fraction" }));
@@ -9,7 +16,9 @@ flicking2.addPlugins(new Flicking.Plugins.Pagination({ type: "fraction" }));
 const flicking3 = new Flicking("#pagination-dynamic");
 
 flicking3.addPlugins(new Flicking.Plugins.Pagination({
-  type: "scroll"
+  type: "scroll",
+  renderBullet: (className, index) => `<span class="${className}">${index + 1}</span>`,
+  renderActiveBullet: (className) => `<span class="${className}"></span>`
 }));
 
 const flicking4 = new Flicking("#pagination-dynamic2");

--- a/test/manual/pagination.html
+++ b/test/manual/pagination.html
@@ -30,6 +30,22 @@
         </div>
         <button id="remove">REMOVE</button>
         <button id="add">ADD</button>
+        <h1 class="title has-text-dark my-4">Pagination</h1>
+        <div id="pagination2" class="flicking-viewport p-2">
+          <div class="flicking-camera">
+            <div class="card mr-2"></div>
+            <div class="card mr-2"></div>
+            <div class="card mr-2"></div>
+            <div class="card mr-2"></div>
+            <div class="card mr-2"></div>
+            <div class="card mr-2"></div>
+            <div class="card mr-2"></div>
+            <div class="card mr-2"></div>
+            <div class="card mr-2"></div>
+            <div class="card mr-2"></div>
+          </div>
+          <div class="flicking-pagination"></div>
+        </div>
         <h1 class="title has-text-dark my-4">Pagination - Fraction</h1>
         <div id="pagination-number" class="flicking-viewport p-2">
           <div class="flicking-camera">

--- a/test/unit/Pagination.spec.ts
+++ b/test/unit/Pagination.spec.ts
@@ -1,4 +1,3 @@
-import Flicking from "@egjs/flicking";
 import * as sinon from "sinon";
 import Pagination from "../../src/pagination/Pagination";
 import { cleanup, createFlicking, createPaginationFixture, sandbox } from "./utils";
@@ -18,9 +17,9 @@ describe("Pagination", () => {
 
   describe("Options", () => {
     describe("renderBullet", () => {
-      it("should not remove custom classes when the 'scroll' type is used", () => {
+      it("should not remove custom classes when the 'scroll' type is used", async () => {
         // Given
-        const flicking = new Flicking(createFixture());
+        const flicking = await createFlicking(createFixture());
         const pagination = new Pagination({
           renderBullet: (className: string) => `<span class="${className} test"></span>`,
           type: "scroll"
@@ -32,6 +31,54 @@ describe("Pagination", () => {
         // Then
         const bullets = [].slice.apply(document.querySelectorAll(".flicking-pagination-bullet"));
         expect(bullets.every(bullet => bullet.classList.contains("test"))).to.be.true;
+      });
+    });
+
+    describe("renderActiveBullet", () => {
+      it("is false by default", async () => {
+        // Given
+        const flicking = await createFlicking(createFixture());
+        const pagination = new Pagination();
+
+        // When
+        pagination.init(flicking);
+
+        // Then
+        expect(pagination.renderActiveBullet).to.be.null;
+      });
+
+      it("should render active bullet if a render function is given", async () => {
+        // Given
+        const flicking = await createFlicking(createFixture());
+        const pagination = new Pagination({
+          type: "bullet", // default
+          renderActiveBullet: (className) => `<span class="${className}">ACTIVE</span>`
+        });
+
+        // When
+        pagination.init(flicking);
+
+        // Then
+        const activeBullet = document.querySelector(".flicking-pagination-bullet-active");
+        expect(activeBullet).not.to.be.null;
+        expect(activeBullet?.innerHTML).to.equal("ACTIVE");
+      });
+
+      it("should render active bullet if a render function is given & type is scroll", async () => {
+        // Given
+        const flicking = await createFlicking(createFixture());
+        const pagination = new Pagination({
+          type: "scroll",
+          renderActiveBullet: (className) => `<span class="${className}">ACTIVE</span>`
+        });
+
+        // When
+        pagination.init(flicking);
+
+        // Then
+        const activeBullet = document.querySelector(".flicking-pagination-bullet-active");
+        expect(activeBullet).not.to.be.null;
+        expect(activeBullet?.innerHTML).to.equal("ACTIVE");
       });
     });
   });


### PR DESCRIPTION
## Details
This adds `renderActiveBulelt` option for the plugin `Pagination`.
- The default value is `null`
- If `null`, the active bullet is rendered with `renderBullet` with `bullet-active` class, same as before.
- If a render function is given, the active bullet is rendered with that function.

## Why is this needed?
The proposed use case is this:
- The pagination should be rendered with a page index inside
  - Like `<span>1</span>`, `<span>2</span>` and so on
- The active pagination bullet should have different text inside.
  - Like `<span>ACTIVE</span>`

A different approach for this(which works well too) is by using CSS `content` and `counter`.
- https://codepen.io/woodneck/pen/RwBjZRE

But, for a11n I had to add this feature.