### PR TITLE
fix: check and recover enabled status of Flicking in Sync plugin

### DIFF
--- a/src/Sync.ts
+++ b/src/Sync.ts
@@ -34,6 +34,7 @@ export interface SychronizableFlickingOptions {
 class Sync implements Plugin {
   /* Internal Values */
   private _flicking: Flicking | null = null;
+  private _disabledIndex: number[] = [];
 
   /* Options */
   private _type: SyncOptions["type"];
@@ -173,19 +174,20 @@ class Sync implements Plugin {
   };
 
   private _onMoveStart = (e: MoveStartEvent): void => {
-    this._synchronizedFlickingOptions.forEach(({ flicking }) => {
-      if (flicking !== e.currentTarget) {
+    this._disabledIndex = [];
+    this._synchronizedFlickingOptions.forEach(({ flicking }, i) => {
+      if (flicking !== e.currentTarget && flicking.control.controller.enabled) {
+        this._disabledIndex.push(i);
         flicking.disableInput();
       }
     });
   };
 
   private _onMoveEnd = (e: MoveEndEvent): void => {
-    this._synchronizedFlickingOptions.forEach(({ flicking }) => {
-      if (flicking !== e.currentTarget) {
-        flicking.enableInput();
-        flicking.control.updateInput();
-      }
+    this._disabledIndex.forEach((i) => {
+      const flicking = this._synchronizedFlickingOptions[i].flicking;
+      flicking.enableInput();
+      flicking.control.updateInput();
     });
   };
 

--- a/test/unit/Sync.spec.ts
+++ b/test/unit/Sync.spec.ts
@@ -168,4 +168,33 @@ describe("Sync", () => {
     expect(flicking1.index).equal(2);
     expect(flicking1.camera.position).equal(flicking1.panels[2].position);
   });
+
+  [true, false].forEach((enabled) => {
+    it(`should check and recover enabled status of flickings (enabled: ${enabled})`, async () => {
+      // Given
+      flicking0.addPlugins(new Sync({
+        type: "camera",
+        synchronizedFlickingOptions: [
+          {
+            flicking: flicking0
+          },
+          {
+            flicking: flicking1
+          }
+        ]
+      }));
+      await waitEvent(flicking0, "ready");
+
+      if (!enabled) {
+        flicking1.disableInput();
+      }
+  
+      // When
+      void flicking0.control.moveToPosition(500, 0);
+
+      // Then
+      expect(flicking1.camera.position).equal(1100);
+      expect(flicking1.control.controller.enabled).equal(enabled);
+    });
+  })
 });


### PR DESCRIPTION
## Issue
#60

## Details
This fixes #60
